### PR TITLE
Added OnSave feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ $ webproc --help
   --trust-proxy, -t         trust proxy HTTP headers to provide remote ip address
   --log, -l                 log mode (must be 'webui' or 'proxy' or 'both' defaults to 'both')
   --on-exit, -o             process exit action (default ignore)
+  --on-save, -s             process save action (default restart)
   --configuration-file, -c  writable configuration file (allows multiple)
   --restart-timeout, -r     restart timeout controls when to perform a force kill (default 30s)
   --max-lines, -m           maximum number of log lines to show in webui (default 5000)
@@ -103,6 +104,11 @@ Log = "both"
 # "proxy" - also exit webproc with the same exit code
 # "restart" - automatically restart with exponential backoff time delay between failed restarts
 OnExit = "ignore"
+
+# OnSave dictates what action to take when saving a configuration file via the UI:
+# "restart" - instantly restart the process
+# "continue" - do not restart the process (restart button must be used)
+OnExit = "restart"
 
 # Configuration files to be editable by the web UI.
 # For example, dnsmasq would include "/etc/dnsmasq.conf"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,13 @@ $ go get -v github.com/jpillora/webproc
 Let's use `webproc` to run `dnsmasq`:
 
 ```
-webproc --config /etc/dnsmasq.conf -- dnsmasq --no-daemon
+webproc --configuration-file /etc/dnsmasq.conf -- dnsmasq --no-daemon
+```
+
+Multiple config files can be specified:
+
+```
+webproc -c /etc/dnsmasq.conf -c /etc/hosts -- dnsmasq --no-daemon
 ```
 
 Visit [http://localhost:8080](http://localhost:8080) and view the process configuration, status and logs.

--- a/agent/agent_http.go
+++ b/agent/agent_http.go
@@ -96,7 +96,7 @@ func (a *agent) serveSave(w http.ResponseWriter, r *http.Request) {
 
 	a.readFiles()
 	time.Sleep(100 * time.Millisecond)
-	a.restart()
+	//a.restart()
 	w.WriteHeader(200)
 	return
 }

--- a/agent/agent_http.go
+++ b/agent/agent_http.go
@@ -96,7 +96,10 @@ func (a *agent) serveSave(w http.ResponseWriter, r *http.Request) {
 
 	a.readFiles()
 	time.Sleep(100 * time.Millisecond)
-	//a.restart()
+	switch a.data.Config.OnSave {
+		case OnSaveRestart:
+			a.restart()
+	}
 	w.WriteHeader(200)
 	return
 }

--- a/agent/config.go
+++ b/agent/config.go
@@ -12,6 +12,7 @@ import (
 type (
 	Log      string
 	OnExit   string
+	OnSave   string
 	Duration time.Duration
 )
 
@@ -23,6 +24,9 @@ const (
 	OnExitRestart OnExit = "restart"
 	OnExitIgnore  OnExit = "ignore"
 	OnExitProxy   OnExit = "proxy"
+
+	OnSaveRestart  OnSave = "restart"
+	OnSaveContinue OnSave = "continue"
 )
 
 //Config is shared for both toml unmarshalling and opts CLI generation.
@@ -38,6 +42,7 @@ type Config struct {
 	ProgramArgs        []string `opts:"mode=arg, name=arg, help=args can be either a command with arguments or a webproc file, min=1"`
 	Log                Log      `opts:"help=log mode (must be 'webui' or 'proxy' or 'both' defaults to 'both')"`
 	OnExit             OnExit   `opts:"help=process exit action, default=ignore"`
+	OnSave             OnSave   `opts:"help=config save action, default=restart"`
 	ConfigurationFiles []string `opts:"mode=flag, help=writable configuration file"`
 	RestartTimeout     Duration `opts:"help=restart timeout controls when to perform a force kill, default=30s"`
 	MaxLines           int      `opts:"help=maximum number of log lines to show in webui, default=5000"`
@@ -86,6 +91,11 @@ func ValidateConfig(c *Config) error {
 	default:
 		c.OnExit = OnExitIgnore
 	}
+	switch c.OnSave {
+	case OnSaveContinue, OnSaveRestart:
+	default:
+		c.OnSave = OnSaveRestart
+	}
 	if c.RestartTimeout <= 0 {
 		c.RestartTimeout = Duration(30 * time.Second)
 	}
@@ -93,6 +103,11 @@ func ValidateConfig(c *Config) error {
 }
 
 // helper types
+
+func (o *OnSave) UnmarshalTOML(data []byte) error {
+	*o = OnSave(quoted(data))
+	return nil
+}
 
 func (o *OnExit) UnmarshalTOML(data []byte) error {
 	*o = OnExit(quoted(data))

--- a/default.toml
+++ b/default.toml
@@ -32,7 +32,7 @@ OnExit = "ignore"
 # OnSave dictates what action to take when saving a configuration file via the UI:
 # "restart" - instantly restart the process
 # "continue" - do not restart the process (restart button must be used)
-OnExit = "restart"
+OnSave = "restart"
 
 # Configuration files to be editable by the web UI.
 # For example, dnsmasq would include "/etc/dnsmasq.conf"

--- a/default.toml
+++ b/default.toml
@@ -29,6 +29,11 @@ Log = "both"
 # It is recommended to use "proxy" and then to run webproc commands via a process manager.
 OnExit = "ignore"
 
+# OnSave dictates what action to take when saving a configuration file via the UI:
+# "restart" - instantly restart the process
+# "continue" - do not restart the process (restart button must be used)
+OnExit = "restart"
+
 # Configuration files to be editable by the web UI.
 # For example, dnsmasq would include "/etc/dnsmasq.conf"
 ConfigurationFiles = []


### PR DESCRIPTION
- Added OnSave params, default is 'restart' (for backwards compatibility). Alternative option is 'continue'. This prevents the running process from restarting after making a change.
- Fixed configuration documentation, this changed from --config to --configuration-file (-c) in a previous release
- Added example for multiple configuration file usage