### PR TITLE
Added OnSave feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ $ webproc --help
   --trust-proxy, -t         trust proxy HTTP headers to provide remote ip address
   --log, -l                 log mode (must be 'webui' or 'proxy' or 'both' defaults to 'both')
   --on-exit, -o             process exit action (default ignore)
+  --on-save, -s             process save action (default restart)
   --configuration-file, -c  writable configuration file (allows multiple)
   --restart-timeout, -r     restart timeout controls when to perform a force kill (default 30s)
   --max-lines, -m           maximum number of log lines to show in webui (default 5000)
@@ -103,6 +104,11 @@ Log = "both"
 # "proxy" - also exit webproc with the same exit code
 # "restart" - automatically restart with exponential backoff time delay between failed restarts
 OnExit = "ignore"
+
+# OnSave dictates what action to take when saving a configuration file via the UI:
+# "restart" - instantly restart the process
+# "continue" - do not restart the process (restart button must be used)
+OnExit = "restart"
 
 # Configuration files to be editable by the web UI.
 # For example, dnsmasq would include "/etc/dnsmasq.conf"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,13 @@ $ go get -v github.com/jpillora/webproc
 Let's use `webproc` to run `dnsmasq`:
 
 ```
-webproc --config /etc/dnsmasq.conf -- dnsmasq --no-daemon
+webproc --configuration-file /etc/dnsmasq.conf -- dnsmasq --no-daemon
+```
+
+Multiple config files can be specified:
+
+```
+webproc -c /etc/dnsmasq.conf -c /etc/hosts -- dnsmasq --no-daemon
 ```
 
 Visit [http://localhost:8080](http://localhost:8080) and view the process configuration, status and logs.

--- a/agent/agent_http.go
+++ b/agent/agent_http.go
@@ -96,7 +96,7 @@ func (a *agent) serveSave(w http.ResponseWriter, r *http.Request) {
 
 	a.readFiles()
 	time.Sleep(100 * time.Millisecond)
-	a.restart()
+	//a.restart()
 	w.WriteHeader(200)
 	return
 }

--- a/agent/agent_http.go
+++ b/agent/agent_http.go
@@ -96,7 +96,10 @@ func (a *agent) serveSave(w http.ResponseWriter, r *http.Request) {
 
 	a.readFiles()
 	time.Sleep(100 * time.Millisecond)
-	//a.restart()
+	switch a.data.Config.OnSave {
+		case OnSaveRestart:
+			a.restart()
+	}
 	w.WriteHeader(200)
 	return
 }

--- a/agent/config.go
+++ b/agent/config.go
@@ -41,8 +41,8 @@ type Config struct {
 	TrustProxy         bool     `opts:"help=trust proxy HTTP headers to provide remote ip address"`
 	ProgramArgs        []string `opts:"mode=arg, name=arg, help=args can be either a command with arguments or a webproc file, min=1"`
 	Log                Log      `opts:"help=log mode (must be 'webui' or 'proxy' or 'both' defaults to 'both')"`
-	OnExit             OnExit   `opts:"help=process exit action, default=ignore"`
-	OnSave             OnSave   `opts:"help=config save action, default=restart"`
+	OnExit             OnExit   `opts:"help=process exit action, short=o, default=ignore"`
+	OnSave             OnSave   `opts:"help=config save action, short=s, default=restart"`
 	ConfigurationFiles []string `opts:"mode=flag, help=writable configuration file"`
 	RestartTimeout     Duration `opts:"help=restart timeout controls when to perform a force kill, default=30s"`
 	MaxLines           int      `opts:"help=maximum number of log lines to show in webui, default=5000"`

--- a/agent/config.go
+++ b/agent/config.go
@@ -12,6 +12,7 @@ import (
 type (
 	Log      string
 	OnExit   string
+	OnSave   string
 	Duration time.Duration
 )
 
@@ -23,6 +24,9 @@ const (
 	OnExitRestart OnExit = "restart"
 	OnExitIgnore  OnExit = "ignore"
 	OnExitProxy   OnExit = "proxy"
+
+	OnSaveRestart  OnSave = "restart"
+	OnSaveContinue OnSave = "continue"
 )
 
 //Config is shared for both toml unmarshalling and opts CLI generation.
@@ -38,6 +42,7 @@ type Config struct {
 	ProgramArgs        []string `opts:"mode=arg, name=arg, help=args can be either a command with arguments or a webproc file, min=1"`
 	Log                Log      `opts:"help=log mode (must be 'webui' or 'proxy' or 'both' defaults to 'both')"`
 	OnExit             OnExit   `opts:"help=process exit action, default=ignore"`
+	OnSave             OnSave   `opts:"help=config save action, default=restart"`
 	ConfigurationFiles []string `opts:"mode=flag, help=writable configuration file"`
 	RestartTimeout     Duration `opts:"help=restart timeout controls when to perform a force kill, default=30s"`
 	MaxLines           int      `opts:"help=maximum number of log lines to show in webui, default=5000"`
@@ -86,6 +91,11 @@ func ValidateConfig(c *Config) error {
 	default:
 		c.OnExit = OnExitIgnore
 	}
+	switch c.OnSave {
+	case OnSaveContinue, OnSaveRestart:
+	default:
+		c.OnSave = OnSaveRestart
+	}
 	if c.RestartTimeout <= 0 {
 		c.RestartTimeout = Duration(30 * time.Second)
 	}
@@ -93,6 +103,11 @@ func ValidateConfig(c *Config) error {
 }
 
 // helper types
+
+func (o *OnSave) UnmarshalTOML(data []byte) error {
+	*o = OnSave(quoted(data))
+	return nil
+}
 
 func (o *OnExit) UnmarshalTOML(data []byte) error {
 	*o = OnExit(quoted(data))

--- a/agent/static/app.css
+++ b/agent/static/app.css
@@ -59,6 +59,7 @@ main {
 .controls .files {
   margin-bottom: 10px;
 }
+
 .controls .files .grouped.fields {
   text-align: left;
 }
@@ -66,6 +67,7 @@ main {
   word-break: break-all;
   text-align: left;
 }
+
 .controls .checkmark.icon {
   margin: 0;
 }

--- a/agent/static/index.html
+++ b/agent/static/index.html
@@ -53,18 +53,12 @@
           </div>
           <div class="files" ng-show="files.length > 1">
             <div class="ui title info field">Files</div>
-            <div class="grouped fields">
-              <div class="field" ng-repeat="f in files">
-                <div class="ui radio checkbox">
-                  <input
-                    type="radio"
-                    id="{{ $index }}"
-                    ng-model="inputs.file"
-                    ng-value="f"
-                  />
-                  <label for="{{ $index }}">{{ f }}</label>
-                </div>
-              </div>
+            <div class="ui field">
+              <select
+                class="ui button"
+                ng-options="f for f in files"
+                ng-model="inputs.file"
+              ></select>
             </div>
           </div>
           <div class="ui title info field">Logging</div>

--- a/agent/static/js/run.js
+++ b/agent/static/js/run.js
@@ -23,7 +23,7 @@ app.run(function($rootScope, $http, $timeout, localOpts) {
     show: localOpts("shown", {
       out: true,
       err: true,
-      agent: true
+      agent: false
     }),
     file: "",
     files: null

--- a/default.toml
+++ b/default.toml
@@ -32,7 +32,7 @@ OnExit = "ignore"
 # OnSave dictates what action to take when saving a configuration file via the UI:
 # "restart" - instantly restart the process
 # "continue" - do not restart the process (restart button must be used)
-OnExit = "restart"
+OnSave = "restart"
 
 # Configuration files to be editable by the web UI.
 # For example, dnsmasq would include "/etc/dnsmasq.conf"

--- a/default.toml
+++ b/default.toml
@@ -29,6 +29,11 @@ Log = "both"
 # It is recommended to use "proxy" and then to run webproc commands via a process manager.
 OnExit = "ignore"
 
+# OnSave dictates what action to take when saving a configuration file via the UI:
+# "restart" - instantly restart the process
+# "continue" - do not restart the process (restart button must be used)
+OnExit = "restart"
+
 # Configuration files to be editable by the web UI.
 # For example, dnsmasq would include "/etc/dnsmasq.conf"
 ConfigurationFiles = []


### PR DESCRIPTION
- Added --on-save ,-s to prevent the handled process restarting when a configuration file is changed. Options here are 'restart' and 'continue'. Restart is the default behaviour to allow backwards compatibility.
- Updated docs to give examples of new --configuration-file directive in a previous version
- Updated docs to show new configuration directive with multiple files
