### PR TITLE
Add static endpoint to read the configuration files

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -259,6 +259,11 @@ func (a *agent) watchFiles() io.Closer {
 	return watcher
 }
 
+func (a *agent) getConfig() map[string]string {
+	a.readFiles()
+	return a.data.Files
+}
+
 func (a *agent) readLog() {
 	for l := range a.msgQueue {
 		a.data.Lock()

--- a/agent/agent_http.go
+++ b/agent/agent_http.go
@@ -28,6 +28,8 @@ func (a *agent) router(w http.ResponseWriter, r *http.Request) {
 		a.serveRefresh(w, r)
 	case "save":
 		a.serveSave(w, r)
+	case "getconfig":
+		a.serveConfig(w, r)
 	default:
 		//fallback to static files
 		a.fs.ServeHTTP(w, r)
@@ -41,6 +43,16 @@ func (a *agent) serveRestart(w http.ResponseWriter, r *http.Request) {
 
 func (a *agent) serveRefresh(w http.ResponseWriter, r *http.Request) {
 	a.readFiles() //user refresh config files
+	w.WriteHeader(200)
+}
+
+func (a *agent) serveConfig(w http.ResponseWriter, r *http.Request) {
+	config, err := json.Marshal(a.getConfig())
+	if err != nil {
+		http.Error(w, "json error", 400)
+		return
+	}
+	w.Write(config)
 	w.WriteHeader(200)
 }
 


### PR DESCRIPTION
Hey @jpillora 

First of all, thanks for the webproc tool, it's fast and simple (KISS) for a project I'm working on.
Unfortunately, while logs and configuration files are available on the `/sync` endpoint they are asynchronous and depend on the subsequent reception of the eventstream. It'd be great if we could get the configuration files from a simple HTTP get request to avoid persistent connections from an external client.

This is what this simple PR does. it exposes the `/getconfig` endpoint returning the configuration files as json.

Thanks